### PR TITLE
added custom loader hook to resolve /opt/nodejs/ modules

### DIFF
--- a/v14.x/Dockerfile
+++ b/v14.x/Dockerfile
@@ -1,6 +1,6 @@
 FROM lambci/lambda-base:build
 
-COPY bootstrap.c bootstrap.js package.json /opt/
+COPY bootstrap.c bootstrap.js package.json esm-loader-hook.mjs /opt/
 
 ARG NODE_VERSION
 

--- a/v14.x/bootstrap.c
+++ b/v14.x/bootstrap.c
@@ -32,6 +32,7 @@ int main(void) {
 
   execv("/opt/bin/node", (char *[]){
                              "node",
+                             "--experimental-loader=/opt/esm-loader-hook.mjs",
                              "--expose-gc",
                              max_semi_space_size,
                              max_old_space_size,

--- a/v14.x/esm-loader-hook.mjs
+++ b/v14.x/esm-loader-hook.mjs
@@ -1,0 +1,10 @@
+export async function resolve(specifier, context, defaultResolve) {
+    try {
+        return await defaultResolve(specifier, {
+            ...context,
+            parentURL: 'file:///opt/nodejs/'
+        }, defaultResolve)
+    } catch (err) {
+        return await defaultResolve(specifier, context, defaultResolve)
+    }
+}


### PR DESCRIPTION
There is still a few things that could be done to make this better.
1) add resolution for `/opt/node${NODE_MAJOR}`
2) add resolution for `/var/runtime`
3) add a flag to use this feature as opposed to always on (but i really think it should just be always there personally)
4) we should probably resolve modules the normal way and then try other directories later, but I wanted to give the user an error that makes sense, so I'm doing that last.

I have to go now, but ill add 1, 2, and 4 later